### PR TITLE
Added enhancement - Macro buttons

### DIFF
--- a/Grbl-Panel/Grbl-Panel.vbproj
+++ b/Grbl-Panel/Grbl-Panel.vbproj
@@ -114,6 +114,12 @@
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="ApplicationEvents.vb" />
+    <Compile Include="GrblMacroButtons.Designer.vb">
+      <DependentUpon>GrblMacroButtons.vb</DependentUpon>
+    </Compile>
+    <Compile Include="GrblMacroButtons.vb">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="GrblOffsets.vb">
       <SubType>Form</SubType>
     </Compile>
@@ -162,6 +168,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="GrblGui.resx">
       <DependentUpon>GrblGui.vb</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="GrblMacroButtons.resx">
+      <DependentUpon>GrblMacroButtons.vb</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="My Project\Resources.resx">
       <CustomToolNamespace>My.Resources</CustomToolNamespace>

--- a/Grbl-Panel/GrblMacroButtons.Designer.vb
+++ b/Grbl-Panel/GrblMacroButtons.Designer.vb
@@ -1,0 +1,204 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class GrblMacroButtons
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()> _
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()> _
+    Private Sub InitializeComponent()
+        Me.gbEditor = New System.Windows.Forms.GroupBox()
+        Me.btnAdd = New System.Windows.Forms.Button()
+        Me.lblGCode = New System.Windows.Forms.Label()
+        Me.tbGCode = New System.Windows.Forms.TextBox()
+        Me.lblName = New System.Windows.Forms.Label()
+        Me.tbName = New System.Windows.Forms.TextBox()
+        Me.btnOK = New System.Windows.Forms.Button()
+        Me.btnCancel = New System.Windows.Forms.Button()
+        Me.dgMacros = New System.Windows.Forms.DataGridView()
+        Me.Column1 = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.Column2 = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.btnDeleteMacro = New System.Windows.Forms.Button()
+        Me.lblStatusLabel = New System.Windows.Forms.Label()
+        Me.gbEditor.SuspendLayout()
+        CType(Me.dgMacros, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.SuspendLayout()
+        '
+        'gbEditor
+        '
+        Me.gbEditor.Controls.Add(Me.btnAdd)
+        Me.gbEditor.Controls.Add(Me.lblGCode)
+        Me.gbEditor.Controls.Add(Me.tbGCode)
+        Me.gbEditor.Controls.Add(Me.lblName)
+        Me.gbEditor.Controls.Add(Me.tbName)
+        Me.gbEditor.Location = New System.Drawing.Point(9, 156)
+        Me.gbEditor.Name = "gbEditor"
+        Me.gbEditor.Size = New System.Drawing.Size(246, 111)
+        Me.gbEditor.TabIndex = 1
+        Me.gbEditor.TabStop = False
+        Me.gbEditor.Text = "Editor"
+        '
+        'btnAdd
+        '
+        Me.btnAdd.Location = New System.Drawing.Point(166, 17)
+        Me.btnAdd.Name = "btnAdd"
+        Me.btnAdd.Size = New System.Drawing.Size(64, 23)
+        Me.btnAdd.TabIndex = 4
+        Me.btnAdd.Text = "Add"
+        Me.btnAdd.UseVisualStyleBackColor = True
+        '
+        'lblGCode
+        '
+        Me.lblGCode.Location = New System.Drawing.Point(9, 51)
+        Me.lblGCode.Name = "lblGCode"
+        Me.lblGCode.Size = New System.Drawing.Size(50, 15)
+        Me.lblGCode.TabIndex = 3
+        Me.lblGCode.Text = "G Code:"
+        Me.lblGCode.TextAlign = System.Drawing.ContentAlignment.TopRight
+        '
+        'tbGCode
+        '
+        Me.tbGCode.AcceptsReturn = True
+        Me.tbGCode.Location = New System.Drawing.Point(62, 48)
+        Me.tbGCode.Multiline = True
+        Me.tbGCode.Name = "tbGCode"
+        Me.tbGCode.ScrollBars = System.Windows.Forms.ScrollBars.Vertical
+        Me.tbGCode.Size = New System.Drawing.Size(168, 57)
+        Me.tbGCode.TabIndex = 2
+        '
+        'lblName
+        '
+        Me.lblName.Location = New System.Drawing.Point(9, 22)
+        Me.lblName.Name = "lblName"
+        Me.lblName.Size = New System.Drawing.Size(50, 15)
+        Me.lblName.TabIndex = 1
+        Me.lblName.Text = "Name:"
+        Me.lblName.TextAlign = System.Drawing.ContentAlignment.TopRight
+        '
+        'tbName
+        '
+        Me.tbName.Location = New System.Drawing.Point(61, 19)
+        Me.tbName.Name = "tbName"
+        Me.tbName.Size = New System.Drawing.Size(99, 20)
+        Me.tbName.TabIndex = 0
+        '
+        'btnOK
+        '
+        Me.btnOK.Location = New System.Drawing.Point(180, 12)
+        Me.btnOK.Name = "btnOK"
+        Me.btnOK.Size = New System.Drawing.Size(75, 23)
+        Me.btnOK.TabIndex = 2
+        Me.btnOK.Text = "OK"
+        Me.btnOK.UseVisualStyleBackColor = True
+        '
+        'btnCancel
+        '
+        Me.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel
+        Me.btnCancel.Location = New System.Drawing.Point(180, 41)
+        Me.btnCancel.Name = "btnCancel"
+        Me.btnCancel.Size = New System.Drawing.Size(75, 23)
+        Me.btnCancel.TabIndex = 3
+        Me.btnCancel.Text = "Cancel"
+        Me.btnCancel.UseVisualStyleBackColor = True
+        '
+        'dgMacros
+        '
+        Me.dgMacros.AllowUserToAddRows = False
+        Me.dgMacros.AllowUserToDeleteRows = False
+        Me.dgMacros.AllowUserToResizeColumns = False
+        Me.dgMacros.AllowUserToResizeRows = False
+        Me.dgMacros.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize
+        Me.dgMacros.Columns.AddRange(New System.Windows.Forms.DataGridViewColumn() {Me.Column1, Me.Column2})
+        Me.dgMacros.EditMode = System.Windows.Forms.DataGridViewEditMode.EditProgrammatically
+        Me.dgMacros.Location = New System.Drawing.Point(21, 12)
+        Me.dgMacros.Name = "dgMacros"
+        Me.dgMacros.ReadOnly = True
+        Me.dgMacros.RowHeadersVisible = False
+        Me.dgMacros.RowHeadersWidthSizeMode = System.Windows.Forms.DataGridViewRowHeadersWidthSizeMode.DisableResizing
+        Me.dgMacros.ScrollBars = System.Windows.Forms.ScrollBars.None
+        Me.dgMacros.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect
+        Me.dgMacros.Size = New System.Drawing.Size(148, 134)
+        Me.dgMacros.TabIndex = 4
+        '
+        'Column1
+        '
+        Me.Column1.HeaderText = "Name"
+        Me.Column1.Name = "Column1"
+        Me.Column1.ReadOnly = True
+        '
+        'Column2
+        '
+        Me.Column2.HeaderText = "GCode"
+        Me.Column2.Name = "Column2"
+        Me.Column2.ReadOnly = True
+        '
+        'btnDeleteMacro
+        '
+        Me.btnDeleteMacro.Location = New System.Drawing.Point(180, 111)
+        Me.btnDeleteMacro.Name = "btnDeleteMacro"
+        Me.btnDeleteMacro.Size = New System.Drawing.Size(74, 34)
+        Me.btnDeleteMacro.TabIndex = 5
+        Me.btnDeleteMacro.Text = "Delete Selected"
+        Me.btnDeleteMacro.UseVisualStyleBackColor = True
+        '
+        'lblStatusLabel
+        '
+        Me.lblStatusLabel.Location = New System.Drawing.Point(12, 272)
+        Me.lblStatusLabel.Name = "lblStatusLabel"
+        Me.lblStatusLabel.Size = New System.Drawing.Size(242, 23)
+        Me.lblStatusLabel.TabIndex = 7
+        '
+        'GrblMacroButtons
+        '
+        Me.AcceptButton = Me.btnOK
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.CancelButton = Me.btnCancel
+        Me.ClientSize = New System.Drawing.Size(271, 294)
+        Me.ControlBox = False
+        Me.Controls.Add(Me.lblStatusLabel)
+        Me.Controls.Add(Me.btnDeleteMacro)
+        Me.Controls.Add(Me.btnCancel)
+        Me.Controls.Add(Me.btnOK)
+        Me.Controls.Add(Me.gbEditor)
+        Me.Controls.Add(Me.dgMacros)
+        Me.MaximumSize = New System.Drawing.Size(287, 333)
+        Me.MinimizeBox = False
+        Me.MinimumSize = New System.Drawing.Size(287, 333)
+        Me.Name = "GrblMacroButtons"
+        Me.Text = "Macro Button Editor"
+        Me.gbEditor.ResumeLayout(False)
+        Me.gbEditor.PerformLayout()
+        CType(Me.dgMacros, System.ComponentModel.ISupportInitialize).EndInit()
+        Me.ResumeLayout(False)
+
+    End Sub
+    Private WithEvents gbEditor As System.Windows.Forms.GroupBox
+    Private WithEvents btnAdd As System.Windows.Forms.Button
+    Private WithEvents lblGCode As System.Windows.Forms.Label
+    Private WithEvents tbGCode As System.Windows.Forms.TextBox
+    Private WithEvents lblName As System.Windows.Forms.Label
+    Private WithEvents tbName As System.Windows.Forms.TextBox
+    Private WithEvents btnOK As System.Windows.Forms.Button
+    Private WithEvents btnCancel As System.Windows.Forms.Button
+    Private WithEvents dgMacros As System.Windows.Forms.DataGridView
+    Friend WithEvents Column1 As System.Windows.Forms.DataGridViewTextBoxColumn
+    Friend WithEvents Column2 As System.Windows.Forms.DataGridViewTextBoxColumn
+    Private WithEvents btnDeleteMacro As System.Windows.Forms.Button
+    Private WithEvents lblStatusLabel As System.Windows.Forms.Label
+End Class

--- a/Grbl-Panel/GrblMacroButtons.resx
+++ b/Grbl-Panel/GrblMacroButtons.resx
@@ -117,70 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="MenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+  <metadata name="Column1.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
   </metadata>
-  <metadata name="ToolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>526, 15</value>
-  </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="btnFileReload.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAcJJREFUWEft
-        lL9LQlEUx/3x1Ofz+SszdJEnQkOIKIR/QKA0ZINDNDRFODY1uDZFU0Q0OkhDg4P0B0g0RTRFY1OTOEY0
-        OMTrc71aiK/J5yC8D1zOeeee9+4933Pvczk4ODgsLbFYbNPv918oitJjPPp8vo6qqg3DMPRxymJIp9MR
-        Fr7FNa2Gx+MZhEKhHXz7yWQyGtU+4YrFvqm6S9VHgUBgj02der3e98mcpmn7WHthoUuM6Xa7P8Lh8JaM
-        /pHL5VQ2dYMrcr4SiYQhZ2wgBXx0iGvqul6X0VlKpRIiSZVQ5VpG54B+niDzOdV3eRQ9/qTKJhI38/l8
-        RGZNwzu7GJON9GVkDljoEDN10MSgujbWkmKxuIqZ5M5HrVbzUMkD7u/iqNCnIyti3opyuSzm7NmAgDu/
-        Mem/GEj87xkQcEa2MSa3YiAjNsAZOMMI6TsyYk2lUhGK3eOanJWWjNpANpvV+OBzMplMjUMz0HuFjV7h
-        ims4jMfj63LGJgqFgjp2hSJ3qNEKBoN1JK/yfIzkr0yN2sThbYwSF0E0Gh312GqInxSLH+AvFv6EVVrS
-        pt8v2DdsDxWa3I61cYqDg4PDMuBy/QBTm19yV5itLgAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="btnFilePause.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABGdBTUEAALGPC/xhBQAAAEBJREFUSEtj
-        GAWjgHaAjY2tCkj9h2EmJqajIHEo2ArEcDlWVtZ2kCBJYNQCgmDUAoJg1AKCYOhbMApGAZGAgQEASONn
-        UbG6bmEAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="btnFileSelect.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABGdBTUEAALGPC/xhBQAAAHxJREFUSEtj
-        GAWjgLaAmZl5N5D6j4xZWVm7eXh4Uvj5+SWAfMoALgvY2Nj6mZiYrgMtkQKKkQ/wWQBiAy25zcfHJwdk
-        kwdwWcDLy6vDzs4eAMJAC0yA4uQBbBYA8WMgPoyEQb4hD+CwAB2D1JAHRi0gCEYtGAWjgBqAgQEAiN5m
-        +5yYLNYAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="btnFileSend.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABGdBTUEAALGPC/xhBQAAAMdJREFUSEtj
-        GAWjgLZAVlZWjpWVdbKMjAwHVIi6QEpKSg5I/WdiYrrIw8OjARGlIoBZAMKMjIxf2dnZk8AS1ALIFsAw
-        CwvLchERET4gm3KAzQIQBgbZXS4uLgsgmzKAywIo/s3GxlZmZGTEBGSTBwhY8BeYwlo1NDRYgGzyAC4L
-        gBH+lJOT0wnIpgzgiOStgoKCIkA25QDNgp/AZFpgZWVFfpijA5gFwFRzk5ub2wgiSkUgLS0tBwyShaKi
-        ojxQoVEwCugOGBgApuw5jJYVGoYAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="btnFileStop.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABGdBTUEAALGPC/xhBQAAAEJJREFUSEvt
-        zLEJAEAMgMDsv/T/AiJYpMuBrXPOqhfLaGJlNLEymlgZTayMJlZGEyujiZXRxMpoYmU0sTKaWOesmPmJ
-        VY9x1qIGtwAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <metadata name="ofdGcodeFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>241, 15</value>
-  </metadata>
-  <metadata name="sfdOffsets.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>625, 15</value>
-  </metadata>
-  <metadata name="ofdOffsets.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>731, 15</value>
-  </metadata>
-  <metadata name="GrblSettingsBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>839, 15</value>
-  </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>60</value>
+  <metadata name="Column2.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
   </metadata>
 </root>

--- a/Grbl-Panel/GrblMacroButtons.vb
+++ b/Grbl-Panel/GrblMacroButtons.vb
@@ -1,0 +1,162 @@
+﻿Imports System.Windows.Forms
+Imports Microsoft.Win32
+Public Class GrblMacroButtons
+    Private bDataChanged As Boolean
+    Private _strRegSubKey As String = "Software\GrblPanel\Macros"
+
+    Private Sub GrblMacroButtons_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
+        Dim retval As Int16
+        If bDataChanged Then
+            retval = MsgBox("Are you sure you want to exit without saving your changes?", MsgBoxStyle.YesNo + MsgBoxStyle.Critical, "Confirm exit without saving.")
+            If retval = vbYes Then
+                e.Cancel = False
+            Else
+                e.Cancel = True
+            End If
+        End If
+    End Sub
+
+    Private Sub GrblMacroButtons_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        FillListFromReg()
+        With dgMacros
+            .Columns(0).Width = .Width         ' resize the first column to the width of the entire grid, this hides the Gcode column
+            If .RowCount = 0 Then              ' if there are no macros add a default one to the list as an example
+                .Rows.Add("Probe", "G38.2 Z-30 F10")
+                bDataChanged = True
+            End If
+        End With
+        btnAdd.Text = "Add"
+        tbName.Text = ""
+        tbGCode.Text = ""
+    End Sub
+
+    Private Sub FillListFromReg()
+        Dim instance As RegistryKey = Registry.CurrentUser.CreateSubKey(_strRegSubKey)
+        Dim aKeyNames() As String = instance.GetSubKeyNames()
+        Dim sTemp As String
+
+        With dgMacros
+            .RowCount = 0                                    ' make sure the grid is empty
+            For Each KeyName As String In aKeyNames          ' add records to the grid 
+                sTemp = instance.OpenSubKey(KeyName).GetValue("GCode", "")
+                .Rows.Add(KeyName, sTemp)
+            Next
+            bDataChanged = False                             ' reset our changed data flag
+        End With
+
+    End Sub
+
+    Private Sub btnOK_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles btnOK.Click
+        SaveMacros()
+        Me.DialogResult = System.Windows.Forms.DialogResult.OK
+        Me.Close()
+    End Sub
+
+    Private Sub SaveMacros()
+        Dim instance As RegistryKey = Registry.CurrentUser
+        Dim aKeyNames() As String = instance.GetSubKeyNames()
+
+        instance.DeleteSubKeyTree(_strRegSubKey)                    ' kill all the macros in the registry
+
+        instance = Registry.CurrentUser.CreateSubKey(_strRegSubKey)
+
+        For Each row As DataGridViewRow In dgMacros.Rows
+            instance.CreateSubKey(row.Cells(0).Value.ToString)
+            instance.OpenSubKey(row.Cells(0).Value.ToString, True).SetValue("GCode", row.Cells(1).Value.ToString)
+        Next
+
+        bDataChanged = False
+    End Sub
+
+    Private Sub btnCancel_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles btnCancel.Click
+        Me.DialogResult = System.Windows.Forms.DialogResult.Cancel
+        Me.Close()
+    End Sub
+
+    Private Sub dgMacros_CellValueChanged(sender As Object, e As DataGridViewCellEventArgs) Handles dgMacros.CellValueChanged
+        bDataChanged = True
+    End Sub
+
+    Private Sub dgMacros_DoubleClick(sender As Object, e As EventArgs) Handles dgMacros.DoubleClick
+        With dgMacros
+            If .CurrentRow.Index >= 0 Then
+                tbName.Text = .Item(0, .CurrentRow.Index).Value
+                tbGCode.Text = .Item(1, .CurrentRow.Index).Value
+                btnAdd.Text = "Update"
+            End If
+        End With
+    End Sub
+
+    Private Sub btnDeleteMacro_Click(sender As Object, e As EventArgs) Handles btnDeleteMacro.Click
+        Dim retval As Int16
+        Dim sMsg As String
+
+        With dgMacros
+            If .CurrentRow.Index >= 0 Then
+                sMsg = "Are you sure you want to delete the " & .Item(0, .CurrentRow.Index).Value.ToString & " macro?"
+                retval = MsgBox(sMsg, MsgBoxStyle.YesNo + MsgBoxStyle.Critical, "Confirm Delete")
+                If retval = vbYes Then
+                    .Rows.Remove(.CurrentRow)
+                    bDataChanged = True
+                End If
+            End If
+        End With
+
+    End Sub
+
+    Private Sub UpdateToolTip(sender As Object, e As MouseEventArgs) Handles btnOK.MouseMove, tbGCode.MouseMove, btnCancel.MouseMove, btnDeleteMacro.MouseMove, dgMacros.MouseMove, gbEditor.MouseMove, tbName.MouseMove, Me.MouseMove
+
+        Dim sTemp As String
+
+        If sender Is tbName Then
+            sTemp = "Name appears on the button, so keep it small"
+        ElseIf sender Is btnDeleteMacro Then
+            sTemp = "Delete the selected macro"
+        ElseIf sender Is dgMacros Then
+            sTemp = "DblClick name to edit macro"
+        ElseIf sender Is btnCancel Then
+            sTemp = "Get me outta here, cancel all changes"
+        ElseIf sender Is tbGCode Then
+            sTemp = "G-Code to send when the button is clicked."
+        ElseIf sender Is btnOK Then
+            sTemp = "Commit all changes to registry and close"
+        Else
+            sTemp = "Limit macros to 5 for best results"
+        End If
+
+        lblStatusLabel.Text = sTemp
+    End Sub
+
+    Private Sub btnAdd_Click(sender As Object, e As EventArgs) Handles btnAdd.Click
+        Dim bMatchFound As Boolean
+
+        If tbName.Text <> "" Then
+            If tbGCode.Text <> "" Then
+                If btnAdd.Text = "Update" Then
+                    For Each row As DataGridViewRow In dgMacros.Rows
+                        If row.Cells(0).Value.ToString = tbName.Text Then
+                            row.Cells(1).Value = tbGCode.Text
+                            bMatchFound = True
+                            Exit For
+                        End If
+                    Next
+                    ' if the user changed the name we cannot update so we need to add
+                    If Not bMatchFound Then
+                        dgMacros.Rows.Add(tbName.Text, tbGCode.Text)
+                    End If
+                Else
+                    dgMacros.Rows.Add(tbName.Text, tbGCode.Text)
+                End If
+                bDataChanged = True
+                btnAdd.Text = "Add"
+                tbGCode.Text = ""
+                tbName.Text = ""
+            Else
+                MsgBox("You need to add some G-code to save a macro", MsgBoxStyle.Information, "Data Validation Error")
+            End If
+        Else
+            MsgBox("You cannot create a macro without a name.", MsgBoxStyle.Information, "Data Validation Error")
+        End If
+    End Sub
+
+End Class

--- a/Grbl-Panel/grblgui.Designer.vb
+++ b/Grbl-Panel/grblgui.Designer.vb
@@ -30,6 +30,7 @@ Partial Class GrblGui
         Me.ExitToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.OptionsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.MacroButtonEditorToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.HelpToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.AboutToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.TabControl1 = New System.Windows.Forms.TabControl()
@@ -334,7 +335,7 @@ Partial Class GrblGui
         '
         'ToolsToolStripMenuItem
         '
-        Me.ToolsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.OptionsToolStripMenuItem})
+        Me.ToolsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.OptionsToolStripMenuItem, Me.MacroButtonEditorToolStripMenuItem})
         Me.ToolsToolStripMenuItem.Name = "ToolsToolStripMenuItem"
         Me.ToolsToolStripMenuItem.Size = New System.Drawing.Size(47, 20)
         Me.ToolsToolStripMenuItem.Text = "Tools"
@@ -342,8 +343,14 @@ Partial Class GrblGui
         'OptionsToolStripMenuItem
         '
         Me.OptionsToolStripMenuItem.Name = "OptionsToolStripMenuItem"
-        Me.OptionsToolStripMenuItem.Size = New System.Drawing.Size(116, 22)
+        Me.OptionsToolStripMenuItem.Size = New System.Drawing.Size(181, 22)
         Me.OptionsToolStripMenuItem.Text = "Options"
+        '
+        'MacroButtonEditorToolStripMenuItem
+        '
+        Me.MacroButtonEditorToolStripMenuItem.Name = "MacroButtonEditorToolStripMenuItem"
+        Me.MacroButtonEditorToolStripMenuItem.Size = New System.Drawing.Size(181, 22)
+        Me.MacroButtonEditorToolStripMenuItem.Text = "Macro Button Editor"
         '
         'HelpToolStripMenuItem
         '
@@ -3194,6 +3201,7 @@ Partial Class GrblGui
     Friend WithEvents tbGrblIP As System.Windows.Forms.TabPage
     Friend WithEvents btnIPConnect As System.Windows.Forms.Button
     Friend WithEvents tbIPAddress As System.Windows.Forms.TextBox
+    Friend WithEvents MacroButtonEditorToolStripMenuItem As System.Windows.Forms.ToolStripMenuItem
 
 
 End Class


### PR DESCRIPTION
Here's the long and short of it. I added three new routines to the bottom of GrblGui, MacroButtonEditorToolStripMenuItem_Click
EnableMacroButtons
MacroButton_Click

I also added a call to EnableMacroButtons near the bottom of grblgui_Load and a new Menu Item under Tools.

There's a new form to allow the user to edit their macros, GrblMacroButtons. This form allows the user to add, edit, and delete macro buttons. The data is stored in the system registry under HKCU\Software\GrblPanel\Macros. Only five buttons can fit in the groupbox comfortably but there's no limit to the number of macros that can be added.

The buttons are dynamically added and removed to gbMDI based on the values found in the registry. When the user clicks one of the buttons the gcode associated with that button is sent using the same mechanism as the MDI Manual Command Send.

When the user enters the Macro Button Editor the first time or if there are no buttons defined at all the editor will load itself with a sample Probe macro. This sample is not saved in the system until the user commits the sample to the registry.

Please let me know your thoughts on this.